### PR TITLE
Added support for HTTPS via 'tls' feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma-client"
 version = "0.1.0"
 
+[features]
+tls = ["hyper-tls"]
 [dependencies]
 futures = "0.1.7"
 ruma-identifiers = "0.6.0"
@@ -21,6 +23,10 @@ url = "1.2.4"
 
 [dependencies.hyper]
 git = "https://github.com/hyperium/hyper"
+
+[dependencies.hyper-tls]
+optional = true
+git = "https://github.com/hyperium/hyper-tls"
 
 [dependencies.ruma-client-api]
 git = "https://github.com/ruma/ruma-client-api"


### PR DESCRIPTION
This PR adds a `tls` feature flag enabling HTTPS support using [hyper_tls](https://github.com/hyperium/hyper-tls)