### PR TITLE
Provide device_id when logging in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 futures = "0.1.14"
 hyper = "0.11.1"
 ruma-api = "0.4.0"
-ruma-client-api = "0.1.0"
+ruma-client-api = {git = 'https://github.com/musoke/ruma-client-api'}
 ruma-identifiers = "0.11.0"
 serde_json = "1.0.2"
 serde_urlencoded = "0.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ where
     /// In contrast to api::r0::session::login::call(), this method stores the
     /// session data returned by the endpoint in this client, instead of
     /// returning it.
-    pub fn log_in(&self, user: String, password: String)
+    pub fn log_in(&self, user: String, password: String, device_id: Option<String>)
     -> impl Future<Item = Session, Error = Error> {
         use api::r0::session::login;
 
@@ -120,6 +120,7 @@ where
             medium: None,
             password,
             user,
+            device_id,
         }).map(move |response| {
             let session = Session::new(response.access_token, response.user_id);
             *data.session.borrow_mut() = Some(session.clone());


### PR DESCRIPTION
The [concurrent PR to ruma-client-api](https://github.com/ruma/ruma-client-api/pull/24) necessitates this change. I will also change the ruma-client-api dependency after that merges.  
This will be a breaking change - shall I start a changelog?

I'll make another PR actually exposing the device_id to consumers of this library shortly.