### PR TITLE
remove conservative_impl_trait feature flag

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,4 +1,3 @@
-#![feature(conservative_impl_trait)]
 #![feature(try_from)]
 
 extern crate futures;

--- a/examples/hello_world_await.rs
+++ b/examples/hello_world_await.rs
@@ -1,4 +1,3 @@
-#![feature(conservative_impl_trait)]
 #![feature(generators)]
 #![feature(proc_macro)]
 #![feature(try_from)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-#![feature(conservative_impl_trait, try_from)]
+#![feature(try_from)]
 
 extern crate futures;
 extern crate hyper;


### PR DESCRIPTION
`conservative_impl_trait` is now stable, and [futures_await now requires `proc_macro_non_items`](https://github.com/alexcrichton/futures-await/commit/f2ffdd60e0b7b66ce4812d9f22afd18c845b1b63)  after changes on nightly.