### PR TITLE
Client struct refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ruma-client-api = "0.2.0"
 ruma-identifiers = "0.11.0"
 serde_json = "1.0.33"
 serde_urlencoded = "0.5.4"
+tokio = "0.1"
 url = "1.7.2"
 
 [dependencies.hyper-tls]
@@ -33,6 +34,8 @@ version = "0.2.2"
 [dev-dependencies]
 ruma-events = "0.11.0"
 tokio = "0.1"
+rpassword = "2.1.0"
+clap = "2.32.0"
 
 [features]
 default = ["tls"]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,70 +1,103 @@
 #![feature(try_from)]
 
-use std::{convert::TryFrom, env, process::exit};
-
-use futures::Future;
-use ruma_client::{self, api::r0, Client};
+use clap::{App, Arg};
+use futures::future::Future;
+use ruma_client::{
+    api::r0::{membership::join_room_by_id_or_alias, send::send_message_event},
+    Client,
+};
 use ruma_events::{
     room::message::{MessageEventContent, MessageType, TextMessageEventContent},
     EventType,
 };
-use ruma_identifiers::RoomAliasId;
-use url::Url;
+use tokio::runtime::current_thread;
 
-// from https://stackoverflow.com/a/43992218/1592377
-macro_rules! clone {
-    (@param _) => ( _ );
-    (@param $x:ident) => ( $x );
-    ($($n:ident),+ => move |$($p:tt),+| $body:expr) => (
-        {
-            $( let $n = $n.clone(); )+
-            move |$(clone!(@param $p),)+| $body
-        }
-    );
-}
+use std::{
+    convert::TryInto,
+    io::{self, Write},
+};
 
-fn hello_world(
-    homeserver_url: Url,
-    room: String,
-) -> impl Future<Item = (), Error = ruma_client::Error> {
-    let client = Client::https(homeserver_url, None).unwrap();
+fn main() {
+    let cli_matches = App::new("ruma-client-hello-world")
+        .about("Write a message to a channel using the specified credentials")
+        .arg(
+            Arg::with_name("room_alias")
+                .short("r")
+                .long("room")
+                .value_name("ROOM_ALIAS")
+                .help("Target room alias; has to exist")
+                .default_value("ruma-client-test-room"),
+        )
+        .arg(
+            Arg::with_name("homeserver")
+                .short("s")
+                .long("server")
+                .value_name("HOMESERVER")
+                .help("The room's and user's homeserver; has to be HTTPS")
+                .default_value("https://matrix.org"),
+        )
+        .arg(
+            Arg::with_name("message")
+                .short("m")
+                .long("message")
+                .value_name("MSG")
+                .help("Whatever you'd like the client to say for you")
+                .default_value("Hello, World"),
+        )
+        .get_matches();
 
-    client.register_guest().and_then(clone!(client => move |_| {
-        r0::alias::get_alias::call(client, r0::alias::get_alias::Request {
-            room_alias: RoomAliasId::try_from(&room[..]).unwrap(),
-        })
-    })).and_then(clone!(client => move |response| {
-        let room_id = response.room_id;
+    // Get the username
+    let mut user = String::new();
+    print!("User: ");
+    io::stdout().flush().unwrap();
+    io::stdin()
+        .read_line(&mut user)
+        .expect("Could not prompt username");
+    user = user.replace('\n', "");
 
-        r0::membership::join_room_by_id::call(client.clone(), r0::membership::join_room_by_id::Request {
-            room_id: room_id.clone(),
+    // Get the password sudo-style (with echo off)
+    let pass = rpassword::prompt_password_stdout("Password: ").unwrap();
+
+    let room_alias = cli_matches.value_of("room_alias").unwrap();
+    let homeserver = cli_matches.value_of("homeserver").unwrap();
+    let message = cli_matches.value_of("message").unwrap();
+
+    let mut client =
+        Client::new_https(homeserver.parse().unwrap()).expect("Could not connect to Matrix");
+
+    // Password is moved into and dropped at the end of log_in()
+    client.log_in(&user, pass, None).expect("Could not log in");
+
+    println!("The logged in client: {:#?}", client);
+
+    let fut = join_room_by_id_or_alias::call(
+        &client,
+        join_room_by_id_or_alias::Request {
+            room_id_or_alias: format!("#{}:matrix.org", room_alias)
+                .as_str()
+                .try_into()
+                .unwrap(),
             third_party_signed: None,
-        }).and_then(move |_| {
-            r0::send::send_message_event::call(client, r0::send::send_message_event::Request {
+        },
+    )
+    .map(|res| res.room_id)
+    .and_then(|room_id| {
+        send_message_event::call(
+            &client,
+            send_message_event::Request {
                 room_id: room_id,
                 event_type: EventType::RoomMessage,
                 txn_id: "1".to_owned(),
                 data: MessageEventContent::Text(TextMessageEventContent {
-                    body: "Hello World!".to_owned(),
+                    body: message.to_owned(),
                     msgtype: MessageType::Text,
                 }),
-            })
-        })
-    })).map(|_| ())
-}
+            },
+        )
+    });
 
-fn main() {
-    let (homeserver_url, room) = match (env::args().nth(1), env::args().nth(2)) {
-        (Some(a), Some(b)) => (a, b),
-        _ => {
-            eprintln!(
-                "Usage: {} <homeserver_url> <room>",
-                env::args().next().unwrap()
-            );
-            exit(1)
-        }
-    };
-
-    tokio::run(hello_world(homeserver_url.parse().unwrap(), room)
-               .map_err(|e| { dbg!(e); () }));
+    println!(
+        "Top-level result: {:?}",
+        current_thread::block_on_all(fut).unwrap()
+    );
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -33,7 +33,7 @@ macro_rules! endpoint {
 
             /// Make a request to this API endpoint.
             pub fn call<C>(
-                client: Client<C>,
+                client: &Client<C>,
                 request: Request,
             ) -> impl Future<Item = Response, Error = Error>
             where

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,35 +4,9 @@ use ruma_identifiers::UserId;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Session {
     /// The access token used for this session.
-    access_token: String,
+    pub access_token: String,
     /// The user the access token was issued for.
-    user_id: UserId,
+    pub user_id: UserId,
     /// The ID of the client device
-    device_id: String,
-}
-
-impl Session {
-    /// Create a new user session from an access token and a user ID.
-    pub fn new(access_token: String, user_id: UserId, device_id: String) -> Self {
-        Session {
-            access_token,
-            user_id,
-            device_id,
-        }
-    }
-
-    /// Get the access token associated with this session.
-    pub fn access_token(&self) -> &str {
-        &self.access_token
-    }
-
-    /// Get the ID of the user the session belongs to.
-    pub fn user_id(&self) -> &UserId {
-        &self.user_id
-    }
-
-    /// Get ID of the device the session belongs to.
-    pub fn device_id(&self) -> &str {
-        &self.device_id
-    }
+    pub device_id: String,
 }


### PR DESCRIPTION
This does some stuff I've found useful, feedback is welcome

Commit message:
Client struct refactor

This commit gets rid of consuming the Client in the API methods (no
cloning needed anymore), moves some stuff around and redefines the
example accordingly.

Cargo.toml:
* Add tokio for logging in synchronously
* Update dev dependencies for the new example

src/api.rs:
* Take Client by reference in the API functions from endpoint!

src/lib.rs:
* Remove ClientData and synchronization primitives
* Turn off Hyper keep-alive when filling self.hyper so that the tokio
  runtime does not hang after requests
* Take the client by reference in all API methods
* Make logging in synchronous

src/session.rs:
* Make all members public
* Remove the getter methods

examples/hello_world:
* Add an easy to use CLI
* Log in as an existing user instead of a guest
* Don't clone the Client struct externally