### PR TITLE
Proposal: derive Serialize and Deserialize for Session

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ serde_json = "1.0.33"
 serde_urlencoded = "0.5.4"
 url = "1.7.2"
 
+[dependencies.serde]
+version = "1.0.87"
+features = ["derive"]
+
 [dependencies.hyper-tls]
 optional = true
 version = "0.3.1"

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,8 @@
 use ruma_identifiers::UserId;
+use serde::{Serialize, Deserialize};
 
 /// A user session, containing an access token and information about the associated user account.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Session {
     /// The access token used for this session.
     access_token: String,


### PR DESCRIPTION
to allow the user easy saving and restoring the session
between runs of their application.

Background: If you don't want to query a user's password every time, you need to store the `Session` returned from `client.log_in`, so you can provide it via `Client::https(url, Some(session))` on next start.
So as Session does not implement Serialize/Deserialize, what I currently do is something like this:

```rust
#[derive(Serialize, Deserialize, Debug)]
// copy of ruma_client::Session for deriving debug & deserialize
struct StoredSession {
    access_token: String,
    user_id: UserId,
    device_id: String,
}
impl From<Session> for StoredSession {
    fn from(session: Session) -> Self {
        StoredSession {
            access_token: session.access_token().into(),
            user_id: session.user_id().clone(),
            device_id: session.device_id().into(),
        }
    }
}

impl Into<Session> for StoredSession {
    fn into(self) -> Session {
        Session::new(self.access_token, self.user_id, self.device_id)
    }
}

…
fn main() {
    let file = fs::File::open("session.ron")?;
    let reader = io::BufReader::new(file);
    let session: StoredSession = ron::de::from_reader(reader).unwrap();
    let session = Some(session.into());
    let client = Client::https(url, session);
    …
}
```

Open to other suggestions. I guess you could argue that you could also invent your own three-line newline separated file format to store the Session manually, but if the session is actually part of a larger configuration struct you store to disk, the benefits of just using serde increase.