### PR TITLE
Add timeout parameter to Client::sync method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-util = "0.3.4"
 http = "0.2.0"
 hyper = "0.13.2"
 hyper-tls = { version = "0.4.1", optional = true }
+js_int = { version = "0.1.2", features = ["serde"] }
 ruma-api = "0.13.0"
 ruma-client-api = "0.6.0"
 ruma-events = "0.15.1"
@@ -29,7 +30,6 @@ serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.47"
 serde_urlencoded = "0.6.1"
 url = "2.1.1"
-js_int = { version = "0.1.2", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "0.2.11", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.47"
 serde_urlencoded = "0.6.1"
 url = "2.1.1"
+js_int = { version = "0.1.2", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "0.2.11", features = ["macros"] }

--- a/examples/message_log.rs
+++ b/examples/message_log.rs
@@ -23,8 +23,12 @@ async fn log_messages(
     // TODO: This is a horrible way to obtain an initial next_batch token that generates way too
     //       much server load and network traffic. Fix this!
 
-    //                                                           vvvvvvvv Skip initial sync reponse
-    let mut sync_stream = Box::pin(client.sync(None, None, false).skip(1));
+    //                                                                                                    vvvvvvvv Skip initial sync reponse
+    let mut sync_stream = Box::pin(
+        client
+            .sync(None, None, false, Some(js_int::UInt::new(30000).unwrap()))
+            .skip(1),
+    );
 
     while let Some(res) = sync_stream.try_next().await? {
         // Only look at rooms the user hasn't left yet

--- a/examples/message_log.rs
+++ b/examples/message_log.rs
@@ -26,7 +26,7 @@ async fn log_messages(
 
     let mut sync_stream = Box::pin(
         client
-            .sync(None, None, SetPresence::Online, Some(js_int::UInt::new(30000).unwrap()))
+            .sync(None, None, SetPresence::Online, Some(js_int::UInt::from(30000u32)))
             .skip(1),
     );
 

--- a/examples/message_log.rs
+++ b/examples/message_log.rs
@@ -23,7 +23,6 @@ async fn log_messages(
     // TODO: This is a horrible way to obtain an initial next_batch token that generates way too
     //       much server load and network traffic. Fix this!
 
-    //                                                                                                    vvvvvvvv Skip initial sync reponse
     let mut sync_stream = Box::pin(
         client
             .sync(None, None, false, Some(js_int::UInt::new(30000).unwrap()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! # let homeserver_url = "https://example.com".parse().unwrap();
 //! # let client = Client::https(homeserver_url, None);
 //! # async {
-//! let mut sync_stream = Box::pin(client.sync(None, None, true));
+//! let mut sync_stream = Box::pin(client.sync(None, None, true, Some(js_int::UInt::new(30000).unwrap())));
 //! while let Some(response) = sync_stream.try_next().await? {
 //!     // Do something with the data in the response...
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ where
         filter: Option<api::r0::sync::sync_events::Filter>,
         since: Option<String>,
         set_presence: bool,
-        timeout: Option<js_int::UInt>
+        timeout: Option<js_int::UInt>,
     ) -> impl Stream<Item = Result<api::r0::sync::sync_events::IncomingResponse, Error>>
            + TryStream<Ok = api::r0::sync::sync_events::IncomingResponse, Error = Error> {
         use api::r0::sync::sync_events;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,7 @@ where
         filter: Option<api::r0::sync::sync_events::Filter>,
         since: Option<String>,
         set_presence: bool,
+        timeout: Option<js_int::UInt>
     ) -> impl Stream<Item = Result<api::r0::sync::sync_events::IncomingResponse, Error>>
            + TryStream<Ok = api::r0::sync::sync_events::IncomingResponse, Error = Error> {
         use api::r0::sync::sync_events;
@@ -320,7 +321,7 @@ where
                         since,
                         full_state: None,
                         set_presence,
-                        timeout: None,
+                        timeout,
                     })
                     .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! # async {
 //! let mut sync_stream = Box::pin(
 //!     client
-//!         .sync(None, None, SetPresence::Online, Some(js_int::UInt::new(30000).unwrap()))
+//!         .sync(None, None, SetPresence::Online, Some(js_int::UInt::from(30000u32)))
 //! );
 //! while let Some(response) = sync_stream.try_next().await? {
 //!     // Do something with the data in the response...


### PR DESCRIPTION
Adds a timeout parameter to the Client::sync method, that is just passed directly into the Request object as one of the parameters.