### PR TITLE
Application service requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,20 @@
 //! ```
 //!
 //! You can also pass an existing session to the `Client` constructor to restore a previous session
-//! rather than calling `log_in`.
+//! rather than calling `log_in`. This can also be used to create a session for an application service
+//! that does not need to log in, but uses the access_token directly:
+//!
+//! ```no_run
+//! use ruma_client::{Client, Session};
+//!
+//! let work = async {
+//!     let homeserver_url = "https://example.com".parse().unwrap();
+//!     let session = Session{access_token: "as_access_token".to_string(), identification: None};
+//!     let client = Client::https(homeserver_url, Some(session));
+//!
+//!     // make calls to the API
+//! };
+//! ```
 //!
 //! For the standard use case of synchronizing with the homeserver (i.e. getting all the latest
 //! events), use the `Client::sync`:
@@ -121,7 +134,7 @@ pub use ruma_identifiers as identifiers;
 mod error;
 mod session;
 
-pub use self::{error::Error, session::Session};
+pub use self::{error::Error, session::Identification, session::Session};
 
 /// A client for the Matrix client-server API.
 #[derive(Debug)]
@@ -225,8 +238,10 @@ where
 
         let session = Session {
             access_token: response.access_token,
-            device_id: response.device_id,
-            user_id: response.user_id,
+            identification: Some(Identification {
+                device_id: response.device_id,
+                user_id: response.user_id,
+            }),
         };
         *self.0.session.lock().unwrap() = Some(session.clone());
 
@@ -253,8 +268,10 @@ where
 
         let session = Session {
             access_token: response.access_token,
-            device_id: response.device_id,
-            user_id: response.user_id,
+            identification: Some(Identification {
+                device_id: response.device_id,
+                user_id: response.user_id,
+            }),
         };
         *self.0.session.lock().unwrap() = Some(session.clone());
 
@@ -290,8 +307,10 @@ where
 
         let session = Session {
             access_token: response.access_token,
-            device_id: response.device_id,
-            user_id: response.user_id,
+            identification: Some(Identification {
+                device_id: response.device_id,
+                user_id: response.user_id,
+            }),
         };
         *self.0.session.lock().unwrap() = Some(session.clone());
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,14 @@ use ruma_identifiers::UserId;
 pub struct Session {
     /// The access token used for this session.
     pub access_token: String,
+    /// Identification information for a user
+    pub identification: Option<Identification>,
+}
+
+/// The identification information about the associated user account if the session is associated with
+/// a single user account.
+#[derive(Clone, Debug, serde::Deserialize, Eq, Hash, PartialEq, serde::Serialize)]
+pub struct Identification {
     /// The user the access token was issued for.
     pub user_id: UserId,
     /// The ID of the client device
@@ -19,8 +27,7 @@ impl Session {
     pub fn new(access_token: String, user_id: UserId, device_id: String) -> Self {
         Self {
             access_token,
-            user_id,
-            device_id,
+            identification: Some(Identification { user_id, device_id }),
         }
     }
 
@@ -32,13 +39,19 @@ impl Session {
 
     /// Get the ID of the user the session belongs to.
     #[deprecated]
-    pub fn user_id(&self) -> &UserId {
-        &self.user_id
+    pub fn user_id(&self) -> Option<&UserId> {
+        if let Some(identification) = &self.identification {
+            return Some(&identification.user_id);
+        }
+        None
     }
 
     /// Get ID of the device the session belongs to.
     #[deprecated]
-    pub fn device_id(&self) -> &str {
-        &self.device_id
+    pub fn device_id(&self) -> Option<&str> {
+        if let Some(identification) = &self.identification {
+            return Some(&identification.device_id);
+        }
+        None
     }
 }


### PR DESCRIPTION
This PR allows application services to use `ruma-client`. The two main changes are:
1. `device_id` and `user_id` inside the session struct are now moved into `Identification` wrapper that is optional because application services only use the `access_token` and change the `user_id` on each request.
2. `request_with_url_params` method added which allows a caller to provide a `HashMap<String, String>`  that appends the values of the HashMap as URL parameters

This allows an application service to create a client:

```
 let session = Session {
  access_token: "application_service_token".to_string(),
  identification: None,
};
let client = Client::new("https://example.com", Some(session));
```

and then call the endpoint as a application service user:

```
let room_id = RoomId::try_from("!roomid:example.com").unwrap();
let mut params = HashMap::new();
params.insert("user_id".to_string(), "@namespace.user:example.com".to_string());
let response = client
    .request_with_url_params(
        get_member_events::Request {
            room_id: ",
            at: None,
            membership: None,
            not_membership: None,
        },
    Some(params),
).await?;
```

The following solutions were also considered, but not implemented:

**add a new parameter to `request`**
In case the client is used with a regular user, the caller would have to pass `None` for all calls because regular users don't need additional parameters.

**separate client**
I didn't find a clean way to separate the two client without duplicated code. A trait with a default implementation would still need a `request` method with url parameters, which would change the API for regular clients and add a parameter that isn't used most of the time or a `request_with_url_params` method would be needed, which can be done without using traits.

**builder pattern**
Something like `client.request(...).with_url_parameters(...).send().await` doesn't work well because either `request` would have to return a `Client`, which would have to store the request that is being built or `request` would have to return a new `Request` struct, but in that case `send` would need to be implemented as part of `Request`, but `Request` would somehow need access to `Client`.

It's been a while since I wrote rust code, that's why I tried to list the different implementations I explored. If there's a better way to do this, I'm happy to close this PR.