### PR TITLE
Use ruma instead of subcrates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.81"
 all-features = true
 
 [features]
-client-api = ["dep:as_variant", "dep:ruma-client-api"]
+client-api = ["dep:as_variant", "ruma/client-api-c"]
 
 # HTTP clients
 hyper = ["dep:http-body-util", "dep:hyper", "dep:hyper-util"]
@@ -42,13 +42,12 @@ hyper-rustls = { version = "0.27.1", optional = true, default-features = false }
 hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.3", optional = true, features = ["client-legacy", "http1", "http2", "tokio"] }
 reqwest = { version = "0.12.4", optional = true, default-features = false }
-ruma-client-api = { version = "0.20.1", optional = true, features = ["client"] }
-ruma-common = { version = "0.15.1", features = ["api"] }
+ruma = { version = "0.12.1", features = ["api"] }
 serde_html_form = "0.2.0"
 tracing = { version = "0.1.30", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-ruma-client-api = { version = "0.20.1", features = ["client"] }
+ruma = { version = "0.12.1", features = ["client-api-c"] }
 tokio-stream = "0.1.8"
 
 [lints.rust]

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,14 +6,16 @@ use std::{
 use assign::assign;
 use async_stream::try_stream;
 use futures_core::stream::Stream;
-use ruma_client_api::{
-    account::register::{self, RegistrationKind},
-    session::login::{self, v3::LoginInfo},
-    sync::sync_events,
-    uiaa::UserIdentifier,
-};
-use ruma_common::{
-    api::{MatrixVersion, OutgoingRequest, SendAccessToken},
+use ruma::{
+    api::{
+        client::{
+            account::register::{self, RegistrationKind},
+            session::login::{self, v3::LoginInfo},
+            sync::sync_events,
+            uiaa::UserIdentifier,
+        },
+        MatrixVersion, OutgoingRequest, SendAccessToken,
+    },
     presence::PresenceState,
     DeviceId, UserId,
 };
@@ -117,7 +119,7 @@ impl<C: HttpClient> Client<C> {
         password: &str,
         device_id: Option<&DeviceId>,
         initial_device_display_name: Option<&str>,
-    ) -> Result<login::v3::Response, Error<C::Error, ruma_client_api::Error>> {
+    ) -> Result<login::v3::Response, Error<C::Error, ruma::api::client::Error>> {
         let login_info = LoginInfo::Password(login::v3::Password::new(
             UserIdentifier::UserIdOrLocalpart(user.to_owned()),
             password.to_owned(),
@@ -140,7 +142,8 @@ impl<C: HttpClient> Client<C> {
     /// returned by the endpoint in this client, in addition to returning it.
     pub async fn register_guest(
         &self,
-    ) -> Result<register::v3::Response, Error<C::Error, ruma_client_api::uiaa::UiaaResponse>> {
+    ) -> Result<register::v3::Response, Error<C::Error, ruma::api::client::uiaa::UiaaResponse>>
+    {
         let response = self
             .send_request(assign!(register::v3::Request::new(), { kind: RegistrationKind::Guest }))
             .await?;
@@ -161,7 +164,8 @@ impl<C: HttpClient> Client<C> {
         &self,
         username: Option<&str>,
         password: &str,
-    ) -> Result<register::v3::Response, Error<C::Error, ruma_client_api::uiaa::UiaaResponse>> {
+    ) -> Result<register::v3::Response, Error<C::Error, ruma::api::client::uiaa::UiaaResponse>>
+    {
         let response = self
             .send_request(assign!(register::v3::Request::new(), {
                 username: username.map(ToOwned::to_owned),
@@ -181,7 +185,7 @@ impl<C: HttpClient> Client<C> {
     /// ```no_run
     /// use std::time::Duration;
     ///
-    /// # use ruma_common::presence::PresenceState;
+    /// # use ruma::presence::PresenceState;
     /// # use tokio_stream::{StreamExt as _};
     /// # let homeserver_url = "https://example.com".to_owned();
     /// # async {
@@ -208,8 +212,9 @@ impl<C: HttpClient> Client<C> {
         mut since: String,
         set_presence: PresenceState,
         timeout: Option<Duration>,
-    ) -> impl Stream<Item = Result<sync_events::v3::Response, Error<C::Error, ruma_client_api::Error>>>
-           + '_ {
+    ) -> impl Stream<
+        Item = Result<sync_events::v3::Response, Error<C::Error, ruma::api::client::Error>>,
+    > + '_ {
         try_stream! {
             loop {
                 let response = self

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use ruma_client_api::discovery::get_supported_versions;
-use ruma_common::api::{MatrixVersion, SendAccessToken};
+use ruma::api::{client::discovery::get_supported_versions, MatrixVersion, SendAccessToken};
 
 use super::{Client, ClientData};
 use crate::{DefaultConstructibleHttpClient, Error, HttpClient, HttpClientExt};
@@ -48,7 +47,7 @@ impl ClientBuilder {
     /// Unless the supported Matrix versions were manually set via
     /// [`supported_matrix_versions`][Self::supported_matrix_versions], this will do a
     /// [`get_supported_versions`] request to find out about the supported versions.
-    pub async fn build<C>(self) -> Result<Client<C>, Error<C::Error, ruma_client_api::Error>>
+    pub async fn build<C>(self) -> Result<Client<C>, Error<C::Error, ruma::api::client::Error>>
     where
         C: DefaultConstructibleHttpClient,
     {
@@ -63,7 +62,7 @@ impl ClientBuilder {
     pub async fn http_client<C>(
         self,
         http_client: C,
-    ) -> Result<Client<C>, Error<C::Error, ruma_client_api::Error>>
+    ) -> Result<Client<C>, Error<C::Error, ruma::api::client::Error>>
     where
         C: HttpClient,
     {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{self, Debug, Display, Formatter};
 
-use ruma_common::api::error::{FromHttpResponseError, IntoHttpError};
+use ruma::api::error::{FromHttpResponseError, IntoHttpError};
 
 /// An error that can occur during client operations.
 #[derive(Debug)]
@@ -25,12 +25,12 @@ pub enum Error<E, F> {
 }
 
 #[cfg(feature = "client-api")]
-impl<E> Error<E, ruma_client_api::Error> {
+impl<E> Error<E, ruma::api::client::Error> {
     /// If `self` is a server error in the `errcode` + `error` format expected
     /// for client-server API endpoints, returns the error kind (`errcode`).
-    pub fn error_kind(&self) -> Option<&ruma_client_api::error::ErrorKind> {
+    pub fn error_kind(&self) -> Option<&ruma::api::client::error::ErrorKind> {
         use as_variant::as_variant;
-        use ruma_client_api::error::FromHttpResponseErrorExt as _;
+        use ruma::api::client::error::FromHttpResponseErrorExt as _;
 
         as_variant!(self, Self::FromHttpResponse)?.error_kind()
     }

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -4,7 +4,7 @@
 use std::{future::Future, pin::Pin};
 
 use bytes::BufMut;
-use ruma_common::{
+use ruma::{
     api::{MatrixVersion, OutgoingRequest, SendAccessToken},
     UserId,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,10 @@
 //! #     .build::<ruma_client::http_client::Dummy>()
 //! #     .await?;
 //!
-//! use ruma_client_api::alias::get_alias;
-//! use ruma_common::{api::MatrixVersion, owned_room_alias_id, room_id};
+//! use ruma::{
+//!     api::{client::alias::get_alias, MatrixVersion},
+//!     owned_room_alias_id, room_id,
+//! };
 //!
 //! let alias = owned_room_alias_id!("#example_room:example.com");
 //! let response = client.send_request(get_alias::v3::Request::new(alias)).await?;
@@ -101,7 +103,9 @@
 
 use std::{any::type_name, future::Future};
 
-use ruma_common::{
+#[doc(no_inline)]
+pub use ruma;
+use ruma::{
     api::{MatrixVersion, OutgoingRequest, SendAccessToken},
     UserId,
 };
@@ -167,9 +171,7 @@ where
 
         let res =
             info_span!("deserialize_response", response_type = type_name::<R::IncomingResponse>())
-                .in_scope(move || {
-                    ruma_common::api::IncomingResponse::try_from_http_response(http_res)
-                })?;
+                .in_scope(move || ruma::api::IncomingResponse::try_from_http_response(http_res))?;
 
         Ok(res)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,14 @@
 //! for the generic parameter. For the client API, there are login and registration methods
 //! provided for the client (feature `client-api`):
 //!
-//! ```ignore
-//! # // HACK: "ignore" the doctest here because client.log_in needs client-api feature.
-//! // type HttpClient = ruma_client::http_client::_;
+//! ```no_run
+//! # #[cfg(feature = "client-api")]
+//! # async {
 //! # type HttpClient = ruma_client::http_client::Dummy;
-//! # let work = async {
 //! let homeserver_url = "https://example.com".to_owned();
-//! let client = ruma::Client::builder()
+//! let client = ruma_client::Client::builder()
 //!     .homeserver_url(homeserver_url)
-//!     .build::<ruma_client::http_client::Dummy>()
+//!     .build::<HttpClient>()
 //!     .await?;
 //!
 //! let session = client
@@ -61,10 +60,11 @@
 //! ```no_run
 //! # #[cfg(feature = "client-api")]
 //! # async {
+//! # type HttpClient = ruma_client::http_client::Dummy;
 //! # let homeserver_url = "https://example.com".to_owned();
 //! # let client = ruma_client::Client::builder()
 //! #     .homeserver_url(homeserver_url)
-//! #     .build::<ruma_client::http_client::Dummy>()
+//! #     .build::<HttpClient>()
 //! #     .await?;
 //!
 //! use ruma::{


### PR DESCRIPTION
Since it is not part of ruma anymore, we can use it.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo clippy --all-features` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
