### PR TITLE
Fix cargo-deny job

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -11,6 +11,7 @@ version = 2
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "MPL-2.0",


### PR DESCRIPTION
Allow new license for webpki-roots.

