### PR TITLE
Remove scheduled job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,14 @@ jobs:
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.81"
+          toolchain: "1.82"
 
       - uses: Swatinem/rust-cache@v2
         with:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          shared-key: msrv1.81
+          shared-key: msrv1.82
 
       - name: Run checks
         run: cargo check --all-features

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -5,32 +5,16 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 on:
-  schedule:
-    # every monday at 4AM (UTC?)
-    - cron: '0 4 * * 1'
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
-  bans-licenses-sources:
-    name: Bans, Licenses, Sources
-    runs-on: ubuntu-latest
-    if: github.event.name != 'schedule'
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check bans licenses sources
-
-  advisories:
-    name: Advisories
+  cargo-deny:
+    name: Bans, Licenses, Sources, Advisories
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check advisories

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.15.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.82"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
GitHub disables scheduled jobs if there hasn't been activity on the repository for the last 60 days. This is likely to happen a lot here since we will probably only update it after breaking ruma releases that should happen every 6 months or so.

