### PR TITLE
Add application service support and improved access token handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Improvements:
 
 Breaking changes:
 
--   Upgrade ruma to 0.13.0.
-    -   `ClientBuilder::supported_matrix_versions()` now takes a `SupportedVersions`.
+- Upgrade ruma to 0.13.0.
+  - `ClientBuilder::supported_matrix_versions()` now takes a `SupportedVersions`.
 
 # 0.15.0
 
@@ -23,11 +23,11 @@ No changes for this version
 
 Breaking changes:
 
--   Remove `isahc` feature
+- Remove `isahc` feature
 
 Improvements:
 
--   Add `error_kind` accessor method to `Error<E, ruma_client_api::Error>`
+- Add `error_kind` accessor method to `Error<E, ruma_client_api::Error>`
 
 # 0.12.0
 
@@ -41,48 +41,48 @@ No changes for this version
 
 Breaking changes:
 
--   Upgrade dependencies
+* Upgrade dependencies
 
 # 0.9.0
 
 Breaking changes:
 
--   Upgrade dependencies
+* Upgrade dependencies
 
 # 0.8.0
 
 Breaking changes:
 
--   Upgrade dependencies
--   The whole `Client` is now feature-gated (`client-api` feature).
-    We may introduce a separate `FederationClient` and possibly other types like
-    that in the future.
+* Upgrade dependencies
+* The whole `Client` is now feature-gated (`client-api` feature).
+  We may introduce a separate `FederationClient` and possibly other types like
+  that in the future.
 
 Improvements:
 
--   Rewrite `Client` initialization and store server-supported Matrix versions in
-    it, to determine whether to use stable, unstable or r0 paths for endpoints
+* Rewrite `Client` initialization and store server-supported Matrix versions in
+  it, to determine whether to use stable, unstable or r0 paths for endpoints
 
 # 0.7.0
 
 Breaking changes:
 
--   Upgrade dependencies
+* Upgrade dependencies
 
 # 0.6.0
 
 Breaking changes:
 
--   Upgrade ruma-client-api to 0.11.0
+* Upgrade ruma-client-api to 0.11.0
 
 # 0.5.0
 
 Breaking changes:
 
--   Make `Client` generic over the http client
--   Make the ruma-client-api dependency optional
--   Upgrade dependencies
+* Make `Client` generic over the http client
+* Make the ruma-client-api dependency optional
+* Upgrade dependencies
 
 Improvements:
 
--   Add support for multiple HTTP clients
+* Add support for multiple HTTP clients

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # [unreleased]
 
+-   Added application service support to `Client` and `ClientBuilder`
+-   `ClientBuilder` now has `is_appservice()` and `always_send_token()` methods to handle all `SendAccessToken` variants
+
 # 0.16.0
 
 Breaking changes:
 
-- Upgrade ruma to 0.13.0.
-  - `ClientBuilder::supported_matrix_versions()` now takes a `SupportedVersions`.
+-   Upgrade ruma to 0.13.0.
+-   `ClientBuilder::supported_matrix_versions()` now takes a `SupportedVersions`.
 
 # 0.15.0
 
@@ -19,11 +22,11 @@ No changes for this version
 
 Breaking changes:
 
-- Remove `isahc` feature
+-   Remove `isahc` feature
 
 Improvements:
 
-- Add `error_kind` accessor method to `Error<E, ruma_client_api::Error>`
+-   Add `error_kind` accessor method to `Error<E, ruma_client_api::Error>`
 
 # 0.12.0
 
@@ -37,48 +40,48 @@ No changes for this version
 
 Breaking changes:
 
-* Upgrade dependencies
+-   Upgrade dependencies
 
 # 0.9.0
 
 Breaking changes:
 
-* Upgrade dependencies
+-   Upgrade dependencies
 
 # 0.8.0
 
 Breaking changes:
 
-* Upgrade dependencies
-* The whole `Client` is now feature-gated (`client-api` feature).
-  We may introduce a separate `FederationClient` and possibly other types like
-  that in the future.
+-   Upgrade dependencies
+-   The whole `Client` is now feature-gated (`client-api` feature).
+    We may introduce a separate `FederationClient` and possibly other types like
+    that in the future.
 
 Improvements:
 
-* Rewrite `Client` initialization and store server-supported Matrix versions in
-  it, to determine whether to use stable, unstable or r0 paths for endpoints
+-   Rewrite `Client` initialization and store server-supported Matrix versions in
+    it, to determine whether to use stable, unstable or r0 paths for endpoints
 
 # 0.7.0
 
 Breaking changes:
 
-* Upgrade dependencies
+-   Upgrade dependencies
 
 # 0.6.0
 
 Breaking changes:
 
-* Upgrade ruma-client-api to 0.11.0
+-   Upgrade ruma-client-api to 0.11.0
 
 # 0.5.0
 
 Breaking changes:
 
-* Make `Client` generic over the http client
-* Make the ruma-client-api dependency optional
-* Upgrade dependencies
+-   Make `Client` generic over the http client
+-   Make the ruma-client-api dependency optional
+-   Upgrade dependencies
 
 Improvements:
 
-* Add support for multiple HTTP clients
+-   Add support for multiple HTTP clients

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # [unreleased]
 
--   Added application service support to `Client` and `ClientBuilder`
--   `ClientBuilder` now has `is_appservice()` and `always_send_token()` methods to handle all `SendAccessToken` variants
+Improvements:
+
+-   `ClientBuilder` now has `token_mode()` which takes a `TokenMode` for correlation to `SendAccessToken` behavior.
 
 # 0.16.0
 
 Breaking changes:
 
 -   Upgrade ruma to 0.13.0.
--   `ClientBuilder::supported_matrix_versions()` now takes a `SupportedVersions`.
+    -   `ClientBuilder::supported_matrix_versions()` now takes a `SupportedVersions`.
 
 # 0.15.0
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,21 +29,18 @@ mod builder;
 pub use self::builder::ClientBuilder;
 
 /// How the client should handle access tokens when making requests.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum TokenMode {
+    #[default]
     /// Send access token only when the endpoint requires it.
     SendIfRequired,
+
     /// Always send access token to all endpoints.
     SendAlways,
+
     /// Use application service token handling.
     AppService,
-}
-
-impl Default for TokenMode {
-    fn default() -> Self {
-        Self::SendIfRequired
-    }
 }
 
 /// A client for the Matrix client-server API.

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,24 @@ mod builder;
 
 pub use self::builder::ClientBuilder;
 
+/// How the client should handle access tokens when making requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TokenMode {
+    /// Send access token only when the endpoint requires it.
+    SendIfRequired,
+    /// Always send access token to all endpoints.
+    SendAlways,
+    /// Use application service token handling.
+    AppService,
+}
+
+impl Default for TokenMode {
+    fn default() -> Self {
+        Self::SendIfRequired
+    }
+}
+
 /// A client for the Matrix client-server API.
 #[derive(Clone, Debug)]
 pub struct Client<C>(Arc<ClientData<C>>);
@@ -41,14 +59,11 @@ struct ClientData<C> {
     /// The underlying HTTP client.
     http_client: C,
 
-    /// Whether the client is for an application service.
-    is_appservice: bool,
-
     /// The access token, if logged in.
     access_token: Mutex<Option<String>>,
 
-    /// Whether the client should always send the access token. Ignored when `is_appservice` is true.
-    always_send_token: bool,
+    /// Mode for handling tokens when making requests.
+    token_mode: TokenMode,
 
     /// The (known) Matrix versions the homeserver supports.
     supported_matrix_versions: SupportedVersions,
@@ -86,15 +101,14 @@ impl<C: HttpClient> Client<C> {
         R: OutgoingRequest,
         F: FnOnce(&mut http::Request<C::RequestBody>) -> Result<(), ResponseError<C, R>>,
     {
-        let is_appservice = self.0.is_appservice;
+        let token_mode = self.0.token_mode;
         let access_token = self.access_token();
-        let always_send_token = self.0.always_send_token;
 
-        let send_access_token = match (is_appservice, always_send_token, access_token.as_deref()) {
-            (true, _, Some(at)) => SendAccessToken::Appservice(at),
-            (false, false, Some(at)) => SendAccessToken::IfRequired(at),
-            (false, true, Some(at)) => SendAccessToken::Always(at),
-            (_, _, None) => SendAccessToken::None,
+        let send_access_token = match (token_mode, access_token.as_deref()) {
+            (TokenMode::AppService, Some(at)) => SendAccessToken::Appservice(at),
+            (TokenMode::SendIfRequired, Some(at)) => SendAccessToken::IfRequired(at),
+            (TokenMode::SendAlways, Some(at)) => SendAccessToken::Always(at),
+            (_, None) => SendAccessToken::None,
         };
 
         send_customized_request(

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,8 +41,14 @@ struct ClientData<C> {
     /// The underlying HTTP client.
     http_client: C,
 
+    /// Whether the client is for an application service.
+    is_appservice: bool,
+
     /// The access token, if logged in.
     access_token: Mutex<Option<String>>,
+
+    /// Whether the client should always send the access token (N/A for appservice).
+    always_send_token: bool,
 
     /// The (known) Matrix versions the homeserver supports.
     supported_matrix_versions: SupportedVersions,
@@ -80,10 +86,15 @@ impl<C: HttpClient> Client<C> {
         R: OutgoingRequest,
         F: FnOnce(&mut http::Request<C::RequestBody>) -> Result<(), ResponseError<C, R>>,
     {
+        let is_appservice = self.0.is_appservice;
         let access_token = self.access_token();
-        let send_access_token = match access_token.as_deref() {
-            Some(at) => SendAccessToken::IfRequired(at),
-            None => SendAccessToken::None,
+        let always_send_token = self.0.always_send_token;
+
+        let send_access_token = match (is_appservice, always_send_token, access_token.as_deref()) {
+            (true, _, Some(at)) => SendAccessToken::Appservice(at),
+            (false, false, Some(at)) => SendAccessToken::IfRequired(at),
+            (false, true, Some(at)) => SendAccessToken::Always(at),
+            (_, _, None) => SendAccessToken::None,
         };
 
         send_customized_request(

--- a/src/client.rs
+++ b/src/client.rs
@@ -47,7 +47,7 @@ struct ClientData<C> {
     /// The access token, if logged in.
     access_token: Mutex<Option<String>>,
 
-    /// Whether the client should always send the access token (N/A for appservice).
+    /// Whether the client should always send the access token. Ignored when `is_appservice` is true.
     always_send_token: bool,
 
     /// The (known) Matrix versions the homeserver supports.

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -47,7 +47,8 @@ impl ClientBuilder {
         Self { access_token, ..self }
     }
 
-    /// Set whether the client should always send the access token (N/A for appservice).
+    /// Set whether the client should always send the access token.
+    /// This setting is ignored if the client is for an application service.
     pub fn always_send_token(self, always_send_token: bool) -> Self {
         Self { always_send_token: Some(always_send_token), ..self }
     }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -12,13 +12,21 @@ use crate::{DefaultConstructibleHttpClient, Error, HttpClient, HttpClientExt};
 /// This type can be used to construct a `Client` through a few method calls.
 pub struct ClientBuilder {
     homeserver_url: Option<String>,
+    is_appservice: Option<bool>,
     access_token: Option<String>,
+    always_send_token: Option<bool>,
     supported_matrix_versions: Option<SupportedVersions>,
 }
 
 impl ClientBuilder {
     pub(super) fn new() -> Self {
-        Self { homeserver_url: None, access_token: None, supported_matrix_versions: None }
+        Self {
+            homeserver_url: None,
+            is_appservice: None,
+            access_token: None,
+            always_send_token: None,
+            supported_matrix_versions: None,
+        }
     }
 
     /// Set the homeserver URL.
@@ -29,9 +37,19 @@ impl ClientBuilder {
         Self { homeserver_url: Some(url), ..self }
     }
 
+    /// Set whether the client is for an application service.
+    pub fn is_appservice(self, is_appservice: bool) -> Self {
+        Self { is_appservice: Some(is_appservice), ..self }
+    }
+
     /// Set the access token.
     pub fn access_token(self, access_token: Option<String>) -> Self {
         Self { access_token, ..self }
+    }
+
+    /// Set whether the client should always send the access token (N/A for appservice).
+    pub fn always_send_token(self, always_send_token: bool) -> Self {
+        Self { always_send_token: Some(always_send_token), ..self }
     }
 
     /// Set the supported Matrix versions.
@@ -91,7 +109,9 @@ impl ClientBuilder {
         Ok(Client(Arc::new(ClientData {
             homeserver_url,
             http_client,
+            is_appservice: self.is_appservice.unwrap_or(false),
             access_token: Mutex::new(self.access_token),
+            always_send_token: self.always_send_token.unwrap_or(false),
             supported_matrix_versions,
         })))
     }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -4,7 +4,7 @@ use ruma::api::{
     client::discovery::get_supported_versions, MatrixVersion, SendAccessToken, SupportedVersions,
 };
 
-use super::{Client, ClientData};
+use super::{Client, ClientData, TokenMode};
 use crate::{DefaultConstructibleHttpClient, Error, HttpClient, HttpClientExt};
 
 /// A [`Client`] builder.
@@ -12,9 +12,8 @@ use crate::{DefaultConstructibleHttpClient, Error, HttpClient, HttpClientExt};
 /// This type can be used to construct a `Client` through a few method calls.
 pub struct ClientBuilder {
     homeserver_url: Option<String>,
-    is_appservice: Option<bool>,
     access_token: Option<String>,
-    always_send_token: Option<bool>,
+    token_mode: TokenMode,
     supported_matrix_versions: Option<SupportedVersions>,
 }
 
@@ -22,9 +21,8 @@ impl ClientBuilder {
     pub(super) fn new() -> Self {
         Self {
             homeserver_url: None,
-            is_appservice: None,
             access_token: None,
-            always_send_token: None,
+            token_mode: TokenMode::default(),
             supported_matrix_versions: None,
         }
     }
@@ -37,20 +35,14 @@ impl ClientBuilder {
         Self { homeserver_url: Some(url), ..self }
     }
 
-    /// Set whether the client is for an application service.
-    pub fn is_appservice(self, is_appservice: bool) -> Self {
-        Self { is_appservice: Some(is_appservice), ..self }
-    }
-
     /// Set the access token.
     pub fn access_token(self, access_token: Option<String>) -> Self {
         Self { access_token, ..self }
     }
 
-    /// Set whether the client should always send the access token.
-    /// This setting is ignored if the client is for an application service.
-    pub fn always_send_token(self, always_send_token: bool) -> Self {
-        Self { always_send_token: Some(always_send_token), ..self }
+    /// Set how access tokens should be handled when making requests.
+    pub fn token_mode(self, token_mode: TokenMode) -> Self {
+        Self { token_mode, ..self }
     }
 
     /// Set the supported Matrix versions.
@@ -110,9 +102,8 @@ impl ClientBuilder {
         Ok(Client(Arc::new(ClientData {
             homeserver_url,
             http_client,
-            is_appservice: self.is_appservice.unwrap_or(false),
             access_token: Mutex::new(self.access_token),
-            always_send_token: self.always_send_token.unwrap_or(false),
+            token_mode: self.token_mode,
             supported_matrix_versions,
         })))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ mod error;
 pub mod http_client;
 
 #[cfg(feature = "client-api")]
-pub use self::client::{Client, ClientBuilder};
+pub use self::client::{Client, ClientBuilder, TokenMode};
 pub use self::{
     error::Error,
     http_client::{DefaultConstructibleHttpClient, HttpClient, HttpClientExt},


### PR DESCRIPTION
## Summary

This PR improves access token handling by introducing a `TokenMode` enum approach.

## Changes Made

### New Features

-   Added `token_mode()` method to `ClientBuilder` that takes a `TokenMode` enum for clean access token behavior configuration
-   **TokenMode Enum**: Introduced `TokenMode` with three variants:
    -   `SendIfRequired` - sends tokens only when required by endpoints (default)
    -   `SendAlways` - always sends tokens to all endpoints
    -   `AppService` - uses application service token handling
-   **Enhanced Token Logic**: Improved `SendAccessToken` handling with proper support for all variants:
    -   `SendAccessToken::Appservice` for application service clients
    -   `SendAccessToken::Always` for clients that should always send tokens
    -   `SendAccessToken::IfRequired` for standard clients (default behavior)
    -   `SendAccessToken::None` for unauthenticated clients

### Implementation Details

-   Added `TokenMode` enum in `client.rs` module and exported in public API
-   Updated `ClientBuilder` with `token_mode` field and `token_mode()` configuration method
-   New `token_mode: TokenMode` field in `ClientData`
-   Enhanced `send_customized_request` method with simplified token handling logic

### Token Sending Logic

The new logic determines token sending behavior based on:

```rust
let send_access_token = match access_token.as_deref() {
    Some(token) => match self.0.token_mode {
        TokenMode::SendIfRequired => SendAccessToken::IfRequired(token),
        TokenMode::SendAlways => SendAccessToken::Always(token),
        TokenMode::AppService => SendAccessToken::Appservice(token),
    },
    None => SendAccessToken::None,
};
```

### Usage Example

Token is sent only if required by default.

```rust
let client = Client::builder()
    .homeserver_url("https://matrix.example.com".to_string())
    .access_token(Some("user_token_here".to_string()))
    .build::<HttpClientType>()
    .await?;
```

Token is handled as application service token.

```rust
let client = Client::builder()
    .homeserver_url("https://matrix.example.com".to_string())
    .token_mode(TokenMode::AppService)
    .access_token(Some("as_token_here".to_string()))
    .build::<HttpClientType>()
    .await?;
```