### PR TITLE
Integrate AppserviceUserIdentity

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -22,7 +22,7 @@ private = { ignore = true }
 
 [bans]
 multiple-versions = "warn"
-wildcards = "deny"
+wildcards = "warn"
 
 [[bans.features]]
 name = "serde_json"
@@ -38,3 +38,6 @@ deny = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = [
+    "https://github.com/ruma/ruma",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
     compatible with all requests from ruma-client-api and ruma-appservice-api.
   - `HttpRequest::RequestBuilder` has an extra `AsRef<[u8]>` bound.
   - Bump MSRV to 1.88
+- `Client::send_request_as()` now takes `AppserviceUserIdentity` instead of `&UserId`.
   
 Improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Breaking changes:
     compatible with all requests from ruma-client-api and ruma-appservice-api.
   - `HttpRequest::RequestBuilder` has an extra `AsRef<[u8]>` bound.
   - Bump MSRV to 1.88
-- `Client::send_request_as()` now takes `AppserviceUserIdentity` instead of `&UserId`.
+  - `Client::send_request_as()` and `HttpClientExt::send_matrix_request_as()` now take `AppserviceUserIdentity`
+    instead of `&UserId`.
   
 Improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Breaking changes:
     compatible with all requests from ruma-client-api and ruma-appservice-api.
   - `HttpRequest::RequestBuilder` has an extra `AsRef<[u8]>` bound.
   - Bump MSRV to 1.88
-  - `Client::send_request_as()` and `HttpClientExt::send_matrix_request_as()` now take `AppserviceUserIdentity`
-    instead of `&UserId`.
+  - `Client::send_request_as()` and `HttpClientExt::send_matrix_request_as()`
+    now take `AppserviceUserIdentity` instead of `&UserId`.
   
 Improvements:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ hyper-rustls = { version = "0.27.1", optional = true, default-features = false }
 hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.3", optional = true, features = ["client-legacy", "http1", "http2", "tokio"] }
 reqwest = { version = "0.12.4", optional = true, default-features = false }
-ruma = { version = "0.14.0", features = ["api"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "a67081e", features = ["api"] }
 serde_html_form = "0.2.0"
 tracing = { version = "0.1.30", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-ruma = { version = "0.14.0", features = ["client-api-c"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "a67081e", features = ["client-api-c"] }
 tokio-stream = "0.1.8"
 
 [lints.rust]

--- a/src/client.rs
+++ b/src/client.rs
@@ -141,8 +141,10 @@ impl<C: HttpClient> Client<C> {
         for<'a> R::Authentication: AuthScheme<Input<'a> = SendAccessToken<'a>>,
         R::PathBuilder: SupportedPathBuilder,
     {
-        self.send_customized_request(request, |uri| Ok(identity.maybe_add_to_uri(uri.uri_mut())?))
-            .await
+        self.send_customized_request(request, |request| {
+            Ok(identity.maybe_add_to_uri(request.uri_mut())?)
+        })
+        .await
     }
 
     /// Log in with a username and password.

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,9 +8,9 @@ use assign::assign;
 use async_stream::try_stream;
 use futures_core::stream::Stream;
 use ruma::{
-    DeviceId, UserId,
+    DeviceId,
     api::{
-        OutgoingRequest, SupportedVersions,
+        AppserviceUserIdentity, OutgoingRequest, SupportedVersions,
         auth_scheme::{AuthScheme, SendAccessToken},
         client::{
             account::register::{self, RegistrationKind},
@@ -23,9 +23,7 @@ use ruma::{
     presence::PresenceState,
 };
 
-use crate::{
-    Error, HttpClient, ResponseError, ResponseResult, add_user_id_to_query, send_customized_request,
-};
+use crate::{Error, HttpClient, ResponseError, ResponseResult, send_customized_request};
 
 mod builder;
 
@@ -133,13 +131,18 @@ impl<C: HttpClient> Client<C> {
     ///
     /// This method is meant to be used by application services when interacting with the
     /// client-server API.
-    pub async fn send_request_as<R>(&self, user_id: &UserId, request: R) -> ResponseResult<C, R>
+    pub async fn send_request_as<R>(
+        &self,
+        identity: AppserviceUserIdentity<'_>,
+        request: R,
+    ) -> ResponseResult<C, R>
     where
         R: OutgoingRequest,
         for<'a> R::Authentication: AuthScheme<Input<'a> = SendAccessToken<'a>>,
         R::PathBuilder: SupportedPathBuilder,
     {
-        self.send_customized_request(request, add_user_id_to_query::<C, R>(user_id)).await
+        self.send_customized_request(request, |uri| Ok(identity.maybe_add_to_uri(uri.uri_mut())?))
+            .await
     }
 
     /// Log in with a username and password.

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -4,16 +4,13 @@
 use std::{future::Future, pin::Pin};
 
 use bytes::BufMut;
-use ruma::{
-    UserId,
-    api::{
-        OutgoingRequest,
-        auth_scheme::{AuthScheme, SendAccessToken},
-        path_builder::PathBuilder,
-    },
+use ruma::api::{
+    AppserviceUserIdentity, OutgoingRequest,
+    auth_scheme::{AuthScheme, SendAccessToken},
+    path_builder::PathBuilder,
 };
 
-use crate::{ResponseError, ResponseResult, add_user_id_to_query};
+use crate::{ResponseError, ResponseResult};
 
 #[cfg(feature = "hyper")]
 mod hyper;
@@ -59,7 +56,6 @@ pub trait DefaultConstructibleHttpClient: HttpClient {
 /// trait should make that relatively easy.
 pub trait HttpClientExt: HttpClient {
     /// Send a strongly-typed matrix request to get back a strongly-typed response.
-    // TODO: `R: 'a` bound should not be needed
     fn send_matrix_request<'a, R>(
         &'a self,
         homeserver_url: &str,
@@ -82,7 +78,6 @@ pub trait HttpClientExt: HttpClient {
 
     /// Turn a strongly-typed matrix request into an `http::Request`, customize it and send it to
     /// get back a strongly-typed response.
-    // TODO: `R: 'a` and `F: 'a` should not be needed
     fn send_customized_matrix_request<'a, R, F>(
         &'a self,
         homeserver_url: &str,
@@ -106,8 +101,8 @@ pub trait HttpClientExt: HttpClient {
         ))
     }
 
-    /// Turn a strongly-typed matrix request into an `http::Request`, add a `user_id` query
-    /// parameter to it and send it to get back a strongly-typed response.
+    /// Turn a strongly-typed matrix request into an `http::Request`, add `user_id` and/or
+    /// `device_id` query parameters to it and send it to get back a strongly-typed response.
     ///
     /// This method is meant to be used by application services when interacting with the
     /// client-server API.
@@ -116,7 +111,7 @@ pub trait HttpClientExt: HttpClient {
         homeserver_url: &str,
         access_token: SendAccessToken<'a>,
         path_builder_input: <R::PathBuilder as PathBuilder>::Input<'_>,
-        user_id: &'a UserId,
+        identity: AppserviceUserIdentity<'a>,
         request: R,
     ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>>
     where
@@ -128,7 +123,7 @@ pub trait HttpClientExt: HttpClient {
             access_token,
             path_builder_input,
             request,
-            add_user_id_to_query::<Self, R>(user_id),
+            |uri| Ok(identity.maybe_add_to_uri(uri.uri_mut())?),
         )
     }
 }

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -56,6 +56,7 @@ pub trait DefaultConstructibleHttpClient: HttpClient {
 /// trait should make that relatively easy.
 pub trait HttpClientExt: HttpClient {
     /// Send a strongly-typed matrix request to get back a strongly-typed response.
+    // TODO: `R: 'a` bound should not be needed
     fn send_matrix_request<'a, R>(
         &'a self,
         homeserver_url: &str,
@@ -78,6 +79,7 @@ pub trait HttpClientExt: HttpClient {
 
     /// Turn a strongly-typed matrix request into an `http::Request`, customize it and send it to
     /// get back a strongly-typed response.
+    // TODO: `R: 'a` and `F: 'a` should not be needed
     fn send_customized_matrix_request<'a, R, F>(
         &'a self,
         homeserver_url: &str,
@@ -123,7 +125,7 @@ pub trait HttpClientExt: HttpClient {
             access_token,
             path_builder_input,
             request,
-            |uri| Ok(identity.maybe_add_to_uri(uri.uri_mut())?),
+            |request| Ok(identity.maybe_add_to_uri(request.uri_mut())?),
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,13 +101,10 @@ use std::{any::type_name, future::Future};
 
 #[doc(no_inline)]
 pub use ruma;
-use ruma::{
-    UserId,
-    api::{
-        OutgoingRequest,
-        auth_scheme::{AuthScheme, SendAccessToken},
-        path_builder::PathBuilder,
-    },
+use ruma::api::{
+    OutgoingRequest,
+    auth_scheme::{AuthScheme, SendAccessToken},
+    path_builder::PathBuilder,
 };
 use tracing::{Instrument, info_span};
 
@@ -175,26 +172,5 @@ where
                 .in_scope(move || ruma::api::IncomingResponse::try_from_http_response(http_res))?;
 
         Ok(res)
-    }
-}
-
-fn add_user_id_to_query<C: HttpClient + ?Sized, R: OutgoingRequest>(
-    user_id: &UserId,
-) -> impl FnOnce(&mut http::Request<C::RequestBody>) -> Result<(), ResponseError<C, R>> + '_ {
-    use assign::assign;
-    use http::uri::Uri;
-
-    move |http_request| {
-        let extra_params = serde_html_form::to_string([("user_id", user_id)]).unwrap();
-        let uri = http_request.uri_mut();
-        let new_path_and_query = match uri.query() {
-            Some(params) => format!("{}?{params}&{extra_params}", uri.path()),
-            None => format!("{}?{extra_params}", uri.path()),
-        };
-        *uri = Uri::from_parts(assign!(uri.clone().into_parts(), {
-            path_and_query: Some(new_path_and_query.parse()?),
-        }))?;
-
-        Ok(())
     }
 }


### PR DESCRIPTION
This PR adds support for ```AppserviceUserIdentity``` in appservice requests and introduces the SupportedPathBuilder trait to handle different PathBuilder types.

Changes:
- Add SupportedPathBuilder trait for VersionHistory and SinglePath path builders
- Update send_request_as to accept AppserviceUserIdentity instead of &UserId
- Add send_customized_request_as function in lib.rs
- Removed send_customized_matrix_request from HttpClientExt and send_customized_request method from Client
- Add C::RequestBody: AsRef<[u8]> bounds required by ruma's try_into_http_request

Breaking changes documented in CHANGELOG.md.